### PR TITLE
修复使用kafka时不打印日志的问题

### DIFF
--- a/hangout-input-plugins/hangout-input-plugins-kafka/pom.xml
+++ b/hangout-input-plugins/hangout-input-plugins-kafka/pom.xml
@@ -18,8 +18,27 @@
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_2.11</artifactId>
-        </dependency>
+            <artifactId>kafka_2.11</artifactId>			
+            <exclusions>
+                     <exclusion>
+                              <groupId>log4j</groupId>
+                              <artifactId>log4j</artifactId>
+                     </exclusion>
+                     <exclusion>
+                              <groupId>org.slf4j</groupId>
+                              <artifactId>slf4j-api</artifactId>
+                     </exclusion>
+                     <exclusion>
+                              <groupId>org.slf4j</groupId>
+                              <artifactId>slf4j-log4j12</artifactId>
+                     </exclusion>
+                 </exclusions>
+         </dependency>
+         <dependency>
+                      <groupId>org.apache.logging.log4j</groupId>
+                      <artifactId>log4j-1.2-api</artifactId>
+                      <version>2.6.2</version>
+         </dependency>
     </dependencies>
 
 


### PR DESCRIPTION
移除log4j依赖，添加log4j-1.2-api.