### PR TITLE
update baseInput.java解决不能多个outputs输出的bug

### DIFF
--- a/hangout-baseplugin/src/main/java/com/ctrip/ops/sysdev/baseplugin/BaseInput.java
+++ b/hangout-baseplugin/src/main/java/com/ctrip/ops/sysdev/baseplugin/BaseInput.java
@@ -149,9 +149,11 @@ public abstract class BaseInput extends Base {
                 }
             }
 
+           Map<String, Object> v;
             while (!from_st.empty()) {
+                v = from_st.pop();
                 for (BaseOutput bo : outputProcessors) {
-                    bo.process(from_st.pop());
+                    bo.process(v);
                 }
             }
 


### PR DESCRIPTION
 
Map<String, Object> v;
            while (!from_st.empty()) {
                v = from_st.pop();
                for (BaseOutput bo : outputProcessors) {
                    bo.process(v);
                }
            }