### PR TITLE
Fix a bug of convert

### DIFF
--- a/hangout-filters/hangout-filters-convert/src/main/java/com/ctrip/ops/sysdev/filters/Convert.java
+++ b/hangout-filters/hangout-filters-convert/src/main/java/com/ctrip/ops/sysdev/filters/Convert.java
@@ -74,6 +74,7 @@ public class Convert extends BaseFilter {
         Iterator<Entry<FieldSetter, Tuple4>> it = f.entrySet().iterator();
         boolean success = true;
         while (it.hasNext()) {
+            boolean flag = true;
             Map.Entry<FieldSetter, Tuple4> entry = it.next();
             FieldSetter fieldSetter = entry.getKey();
             Tuple4 t4 = entry.getValue();
@@ -82,10 +83,11 @@ public class Convert extends BaseFilter {
                 TemplateRender tr = (TemplateRender) t4._2();
                 d = ((ConverterI) t4._1()).convert(tr.render(event));
             } catch (Exception e) {
+                flag = false;
                 success = false;
             }
 
-            if (!success || d == null) {
+            if (!flag || d == null) {
                 if ((Boolean) t4._3()) {
                     fieldSetter.setField(event, null);
                 } else {


### PR DESCRIPTION
Success 变量在循环外面，导致前面的转化错误会影响后面的结果

For example：

```
public void testConvertFilter() throws UnsupportedEncodingException {
        String c = String.format("%s\n%s\n%s\n%s\n%s\n%s\n%s",
                "        fields:",
                "            cs_bytes: ",
                "                to: integer",
                "                setto_if_fail: 12",
                "            time_taken: ",
                "                to: float",
                "                setto_if_fail: 0.0");
        Yaml yaml = new Yaml();
        Map config = (Map) yaml.load(c);
        Assert.assertNotNull(config);

        Convert convertFilter = new Convert(config);

        // Match
        Map event = new HashMap();
        event.put("cs_bytes", "");
        event.put("time_taken", "11.11");

        event = convertFilter.process(event);
        Assert.assertEquals(event.get("cs_bytes"), 12);
        Assert.assertEquals(event.get("time_taken"), 11.11F);
        Assert.assertEquals(((ArrayList) event.get("tags")).get(0),
                "convertfail");

```

