### PR TITLE
Fix the dependency conflict issue

### DIFF
--- a/hangout-filters/hangout-filters-grok/pom.xml
+++ b/hangout-filters/hangout-filters-grok/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>org.jruby.joni</groupId>
             <artifactId>joni</artifactId>
-            <version>2.1.8</version>
+            <version>2.1.12</version>
         </dependency>
         <dependency>
             <groupId>org.jruby.jcodings</groupId>


### PR DESCRIPTION
Fix the dependency conflict issue #163 by solution 2 update direct dependency org.jruby.joni:joni from 2.1.8 to 2.1.12.